### PR TITLE
Text Parsing Enabled

### DIFF
--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -7,7 +7,7 @@ on run argv
     set focusedDocument to null
 
     -- parse Alfred's input to separate items
-    set alfredInput to argv
+    set alfredInput to argv as text
     set alfredInput to text items of alfredInput
     tell application "OmniFocus"
         tell front document

--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -1,12 +1,46 @@
 on run argv
-set alfredInput to argv
--- TODO: fix focusedDocument input
+
+-- declaring variables
+set setName to null
+set setContext to null
+set setDueDate to date current date
 set focusedDocument to null
+
+-- parse Alfred's input to separate items
+
+set AppleScript's text item delimiters to {" | "}
+set alfredInput to argv
+set alfredInput to "Journalese Reading Questions | Intermediate Composition | 10-16-17"
+
+
 tell application "OmniFocus"
-    if focusedDocument is null then
-        parse tasks into default document with transport text alfredInput
-    else
-        parse tasks into focusedDocument with transport text alfredInput
-    end if
+    tell front document
+        -- ORDER OF INPUT: Name, Context, Due Date
+        set alfredInput to text items of alfredInput
+        set setName to item 1 of alfredInput
+        set setContext to first flattened context where its name is (item 2 of alfredInput)
+        -- set setDueDate to date item 3 of alfredInput
+
+
+        if focusedDocument is null then
+            -- DEPRECATED --
+            -- parse tasks into default document with transport text alfredInput
+
+            make new task with properties { ¬
+                name:setName, ¬
+                context:setContext, ¬
+                due date:setDueDate ¬
+            }
+        else
+            -- DEPRECATED --
+            -- parse tasks into focusedDocument with transport text alfredInput
+
+            make new task with properties { ¬
+                name:setName, ¬
+                context:setContext, ¬
+                due date:setDueDate ¬
+            }
+        end if
+    end tell
 end tell
 end run

--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -1,4 +1,5 @@
 on run argv
+	set AppleScript's text item delimiters to {" | "}
 
     -- declaring variables
     set setName to null
@@ -6,14 +7,11 @@ on run argv
     set focusedDocument to null
 
     -- parse Alfred's input to separate items
-
-    set AppleScript's text item delimiters to {" | "}
     set alfredInput to argv
-
+    set alfredInput to text items of alfredInput
     tell application "OmniFocus"
         tell front document
             -- ORDER OF INPUT: Name, Context, Due Date
-            set alfredInput to text items of alfredInput
             set setName to item 1 of alfredInput
             set setContext to first flattened context where its name is (item 2 of alfredInput)
             -- set setDueDate to date item 3 of alfredInput

--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -9,7 +9,6 @@ on run argv
 
     set AppleScript's text item delimiters to {" | "}
     set alfredInput to argv
-    set alfredInput to "Hello World 2.0 | Mac"
 
     tell application "OmniFocus"
         tell front document

--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -9,7 +9,7 @@ on run argv
 
     set AppleScript's text item delimiters to {" | "}
     set alfredInput to argv
-
+    set alfredInput to "Hello World 2.0 | Mac"
 
     tell application "OmniFocus"
         tell front document
@@ -18,10 +18,9 @@ on run argv
             set setName to item 1 of alfredInput
             set setContext to first flattened context where its name is (item 2 of alfredInput)
             -- set setDueDate to date item 3 of alfredInput
-            make new task with properties { ¬
+            make new inbox task with properties { ¬
                 name:setName, ¬
-                context:setContext, ¬
-                due date:setDueDate ¬
+                context:setContext ¬
             }
         end tell
     end tell

--- a/OmniFocus.applescript
+++ b/OmniFocus.applescript
@@ -1,46 +1,28 @@
 on run argv
 
--- declaring variables
-set setName to null
-set setContext to null
-set setDueDate to date current date
-set focusedDocument to null
+    -- declaring variables
+    set setName to null
+    set setContext to null
+    set focusedDocument to null
 
--- parse Alfred's input to separate items
+    -- parse Alfred's input to separate items
 
-set AppleScript's text item delimiters to {" | "}
-set alfredInput to argv
-set alfredInput to "Journalese Reading Questions | Intermediate Composition | 10-16-17"
+    set AppleScript's text item delimiters to {" | "}
+    set alfredInput to argv
 
 
-tell application "OmniFocus"
-    tell front document
-        -- ORDER OF INPUT: Name, Context, Due Date
-        set alfredInput to text items of alfredInput
-        set setName to item 1 of alfredInput
-        set setContext to first flattened context where its name is (item 2 of alfredInput)
-        -- set setDueDate to date item 3 of alfredInput
-
-
-        if focusedDocument is null then
-            -- DEPRECATED --
-            -- parse tasks into default document with transport text alfredInput
-
+    tell application "OmniFocus"
+        tell front document
+            -- ORDER OF INPUT: Name, Context, Due Date
+            set alfredInput to text items of alfredInput
+            set setName to item 1 of alfredInput
+            set setContext to first flattened context where its name is (item 2 of alfredInput)
+            -- set setDueDate to date item 3 of alfredInput
             make new task with properties { ¬
                 name:setName, ¬
                 context:setContext, ¬
                 due date:setDueDate ¬
             }
-        else
-            -- DEPRECATED --
-            -- parse tasks into focusedDocument with transport text alfredInput
-
-            make new task with properties { ¬
-                name:setName, ¬
-                context:setContext, ¬
-                due date:setDueDate ¬
-            }
-        end if
+        end tell
     end tell
-end tell
 end run


### PR DESCRIPTION
Code overhaul. Uses delimiters to parse Alfred input `argv` as separate inputs as text, allowing contexts to be dictated. No error catching as of yet, nor any other settings besides dictating contexts. But it makes expanding a lot easier.